### PR TITLE
Icons for github, youtube, mc-rtc on home page

### DIFF
--- a/index_en.html
+++ b/index_en.html
@@ -66,7 +66,7 @@ title: CNRS-AIST JRL
 	<tbody>
 	  <tr>
 	    <td style="padding-bottom:10px">
-	      <a href="https://github.com/isri-aist">
+	      <a href="https://github.com/jrl-umi3218/">
 	      <img src="{{site.baseurl}}/en/assets/icons/GitHub-Mark-Light-64px.png" width="40" alt="GitHub">
 	      </a>
 	    </td>

--- a/index_en.html
+++ b/index_en.html
@@ -61,6 +61,33 @@ title: CNRS-AIST JRL
         </div>
       </div>
     </div>
+    <div align="right" style="padding-right:20px;">
+      <table>
+	<tbody>
+	  <tr>
+	    <td style="padding-bottom:10px">
+	      <a href="https://github.com/isri-aist">
+	      <img src="{{site.baseurl}}/en/assets/icons/GitHub-Mark-Light-64px.png" width="40" alt="GitHub">
+	      </a>
+	    </td>
+	  </tr>
+	  <tr>
+	    <td style="padding-bottom:10px">
+	      <a href="https://www.youtube.com/channel/UCYwHCdMHAKYZJ2MQIoTavVQ">
+	      <img src="{{site.baseurl}}/en/assets/icons/yt_logo_small.png" width="40" alt="YouTube Channel">
+	      </a>
+	    </td>
+	  </tr>
+	  <tr>
+	    <td style="padding-bottom:10px">
+	      <a href="https://jrl-umi3218.github.io/mc_rtc/">
+	      <img src="{{site.baseurl}}/en/assets/icons/mc_rtc.png" width="40" alt="mc-rtc">
+	      </a>
+	    </td>
+	  </tr>
+	</tbody>
+      </table>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
Very basic implementation to show 3 icons for
- github (isri-aist)
- youtube channel
- mc-rtc website
on index_en.html